### PR TITLE
Fix extra tab showing by hiding leftover screen

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -117,6 +117,7 @@ function InnerTabs() {
             'growth/store',
             'growth/dictionary',
             'index',
+            'two',
           ].map((name) => (
             <Tabs.Screen key={name} name={name} options={{ href: null }} />
           ))}


### PR DESCRIPTION
## Summary
- hide the unused `two` route in bottom tabs so only the desired four tabs show

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684683da5c9c832684b9cfca104c4082