### PR TITLE
Fix loops in state tracking

### DIFF
--- a/components/useClientOnlyValue.web.ts
+++ b/components/useClientOnlyValue.web.ts
@@ -4,8 +4,13 @@ import React from 'react';
 // we can use this to determine if we're on the server or not.
 export function useClientOnlyValue<S, C>(server: S, client: C): S | C {
   const [value, setValue] = React.useState<S | C>(server);
+  const lastClientRef = React.useRef(client);
+
   React.useEffect(() => {
-    setValue(client);
+    if (lastClientRef.current !== client) {
+      lastClientRef.current = client;
+      setValue(client);
+    }
   }, [client]);
 
   return value;

--- a/features/add/index.tsx
+++ b/features/add/index.tsx
@@ -209,11 +209,22 @@ export default function AddTaskScreen() {
            customUnit !== initialFormState.customUnit)
         );
     }
-    setUnsaved(formChanged);
+    if (unsaved !== formChanged) {
+      setUnsaved(formChanged);
+    }
   }, [
-    title, memo, selectedUris, folder, currentDeadlineSettings,
-    notificationActive, customAmount, customUnit,
-    initialFormState, currentDraftId, setUnsaved
+    title,
+    memo,
+    selectedUris,
+    folder,
+    currentDeadlineSettings,
+    notificationActive,
+    customAmount,
+    customUnit,
+    initialFormState,
+    currentDraftId,
+    unsaved,
+    setUnsaved,
   ]);
 
 

--- a/features/add_edit/screens/EditTaskScreen.tsx
+++ b/features/add_edit/screens/EditTaskScreen.tsx
@@ -114,8 +114,22 @@ export default function EditTaskScreen() {
       notificationActive !== originalTask.notifyEnabled ||
       customUnit !== originalTask.customUnit ||
       customAmount !== originalTask.customAmount;
-    setUnsaved(changed);
-  }, [title, memo, selectedUris, folder, currentDeadlineSettings, notificationActive, customUnit, customAmount, originalTask, setUnsaved]);
+    if (unsaved !== changed) {
+      setUnsaved(changed);
+    }
+  }, [
+    title,
+    memo,
+    selectedUris,
+    folder,
+    currentDeadlineSettings,
+    notificationActive,
+    customUnit,
+    customAmount,
+    originalTask,
+    unsaved,
+    setUnsaved,
+  ]);
 
   useEffect(() => {
     const unsub = navigation.addListener('beforeRemove', (e:any) => {


### PR DESCRIPTION
## Summary
- avoid repeated updates in useClientOnlyValue hook
- guard unsaved state updates in Add and EditTask screens

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468cc386588326be39f880babd8de6